### PR TITLE
Add dynamic session names

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -22,7 +22,9 @@ exclude_path_components:  # search branches will be pruned the path being explor
   - target
 
 max_search_depth: 5  # how deep we should search for workspaces (default: 3)
-session_name_path_components: 3    # how many parts of the workspace path to use in generating the session name (to avoid collisions) (default: 2)
+session_name_path_components: 3    # how many parts of the workspace path to use in generating the session name by default
+                                   # if you attempt to open two separate workspaces that would generate the same session name,
+                                   # this value will be incremented until a unique session name is found
 
 workspace_definitions:             # our list of workspaces, each with different properties
     - name: python                 # they all have to be named

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ impl TryFrom<RawTwmGlobal> for TwmGlobal {
             .collect();
 
         let max_search_depth = raw_config.max_search_depth.unwrap_or(3);
-        let session_name_path_components = raw_config.session_name_path_components.unwrap_or(2);
+        let session_name_path_components = raw_config.session_name_path_components.unwrap_or(1);
 
         // originally i didnt want to do this here but it takes essentially no time
         // and makes the experience using it better imo


### PR DESCRIPTION
Increases the number of path components used in the session name when encountering a collision. This allows the user to keep a lower `session_name_path_components` value configured while still ensuring unique session names.

Also change the default value for `session_name_path_components` to 1 since collisions are now handled automatically