### PR TITLE
Add ability to match on multiple required files

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -35,12 +35,28 @@ workspace_definitions:             # our list of workspaces, each with different
         - Pipfile
       default_layout: python-dev   # the hierarchy for how a layout gets chosen is user opts to select manually > local layout > default for workspace type
 
+    - name: go
+      has_all_files:               # if all files match this list, we consider it a match, since its "has_all_files"
+        - go.mod
+        - go.sum
+
+    - name: docker-compose         # you can also combine conditions, as in this example, a docker-compose workspace is matched only if we have *any* of the docker-compose files and both `.git` folder and a `Dockerfile`
+      has_any_file:
+        - docker-compose.yaml
+        - docker-compose.yml
+      has_all_files:
+        - Dockerfile
+        - .git
+
     - name: node                   # the order of these definitions matters - if a directory matches multiple, the first one wins
       has_any_file:
         - package.json
         - yarn.lock
         - .nvmrc
       default_layout: node-dev
+
+    - name: catchall               # without any conditions, all directories will match this wworkspace
+      default_layout: catchall-dev # this is the default layout for this workspace type
 
     - name: rust
       has_any_file:
@@ -68,6 +84,10 @@ layouts:                           # our list of layouts just have names and a l
         - tmux resize-pane -x 80
         - tmux select-pane -t 0
         - tmux send-keys -t 1 'cargo watch -x test -x run' C-m
+        - nvim .
+
+    - name: catchall-dev
+      commands:
         - nvim .
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod config;
 pub mod matches;
 pub mod picker;
 pub mod tmux;
+pub mod workspace_conditions;

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -65,12 +65,20 @@ pub fn find_workspaces_in_dir<'a>(
         let mut workspace_type: Option<&'a str> = None;
 
         for (_, workspace_definition) in &config.workspace_definitions {
-            for file_name in &workspace_definition.has_any_file {
-                if entry.path().join(file_name).exists() {
-                    workspace_type = Some(workspace_definition.name.as_str());
-                    break;
-                }
+            if workspace_definition
+                .conditions
+                .iter()
+                .all(|c| c.meets_condition(entry.path()))
+            {
+                workspace_type = Some(workspace_definition.name.as_str());
+                break;
             }
+            // for file_name in &workspace_definition.has_any_file {
+            //     if entry.path().join(file_name).exists() {
+            //         workspace_type = Some(workspace_definition.name.as_str());
+            //         break;
+            //     }
+            // }
             if workspace_type.is_some() {
                 break;
             }

--- a/src/workspace_conditions.rs
+++ b/src/workspace_conditions.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+pub trait WorkspaceCondition {
+    fn meets_condition(&self, path: &Path) -> bool;
+}
+
+pub struct HasAnyFileCondition {
+    pub files: Vec<String>,
+}
+
+impl WorkspaceCondition for HasAnyFileCondition {
+    fn meets_condition(&self, path: &Path) -> bool {
+        for file in &self.files {
+            if path.join(file).exists() {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+pub struct HasAllFilesCondition {
+    pub files: Vec<String>,
+}
+
+impl WorkspaceCondition for HasAllFilesCondition {
+    fn meets_condition(&self, path: &Path) -> bool {
+        for file in &self.files {
+            if !path.join(file).exists() {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// A condition that always returns true, used as a default condition if no others
+/// are specified.
+pub struct NullCondition {}
+
+impl WorkspaceCondition for NullCondition {
+    fn meets_condition(&self, _path: &Path) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
Now can have multiple files that are required to
meet a given workspace definition.

Additionally, you can now combine conditions, e.g. `has_any_file` and `has_all_files` in the same workspace.

This will generally be true going forward, where any new configurable conditions will be able to used in combination with each other.