### PR TITLE
Fix build on aarch64

### DIFF
--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -3,7 +3,7 @@ use crate::config::{TwmGlobal, TwmLocal};
 use crate::matches::SafePath;
 use crate::picker::get_skim_selection_from_slice;
 use anyhow::{bail, Context, Result};
-use libc::execvp;
+use libc::{execvp,c_char};
 use std::ffi::CString;
 use std::path::Path;
 use std::process::{Command, Output};
@@ -101,9 +101,9 @@ fn attach_to_tmux_session_outside_tmux(repo_name: &str) -> Result<()> {
         CString::new(repo_name).with_context(|| "Unable to turn repo name to a cstring.")?,
     ];
 
-    let tmux_attach_args_ptrs: Vec<*const i8> = tmux_attach_args
+    let tmux_attach_args_ptrs: Vec<*const c_char> = tmux_attach_args
         .iter()
-        .map(|arg| arg.as_ptr())
+        .map(|arg| arg.as_ptr() as *const c_char)
         .chain(std::iter::once(std::ptr::null()))
         .collect();
 


### PR DESCRIPTION
`attach_to_tmux_session_outside_tmux` uses raw pointers to `c_char` under the hood, but these were specified explicitly as `*const i8` instead of `*const c_char`. As the documentation for `CString::as_ptr` [^1] points out, the method really returns a `*const c_char`, and the actual referenced byte type (`i8` or `u8`) is architecture dependent:

> The type of the returned pointer is *const c_char, and whether it’s an
> alias for *const i8 or *const u8 is platform-specific.

Changing the pointer type to `*const c_char` explicitly fixes the build on aarch64, where the underlying pointer type is actually `*const u8` instead of `*const i8`.

[^1]: https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.as_ptr