### PR TITLE
Add -g option for attaching to existing group

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1715653339,
-        "narHash": "sha256-7lR9tpVXviSccl07GXI0+ve/natd24HAkuy1sQp0OlI=",
+        "lastModified": 1715774670,
+        "narHash": "sha256-iJYnKMtLi5u6hZhJm94cRNSDG5Rz6ZzIkGbhPFtDRm0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "abd6d48f8c77bea7dc51beb2adfa6ed3950d2585",
+        "rev": "b3fcfcfabd01b947a1e4f36622bbffa3985bdac6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
         rustVersion = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
-          extensions = [ "rust-src" "rust-analyzer" "cargo" ];
+          extensions = [ "rust-src" "rust-analyzer" "cargo" "rustc" ];
         });
         naersk-lib = pkgs.callPackage naersk { };
 
@@ -35,11 +35,12 @@
         };
 
         devShell = with pkgs; mkShell {
-          buildInputs = [
+          buildInputs = with pkgs; [
             rustVersion
+            pkg-config
           ];
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
-          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+          PKG_CONFIG_PATH = lib.makeBinPath [ pkg-config ];
         };
       });
 }


### PR DESCRIPTION
Adds an option `-g/--group` that opens a fuzzy finder with current sessions, and starts a new session in a group with  the selected session

note: you can still use `-g` with `-d` and `-n`

closes #19 