### PR TITLE
Add CLI options for printing schema & writing a default config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +791,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +834,17 @@ name = "serde_derive"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -974,7 +1015,9 @@ dependencies = [
  "libc",
  "nucleo",
  "ratatui",
+ "schemars",
  "serde",
+ "serde_json",
  "shellexpand",
  "walkdir",
  "xdg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ enum_dispatch = "0.3.13"
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 nucleo = "0.5.0"
 ratatui = "0.26.3"
+serde_json = "1.0.117"
+schemars = "0.8.21"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::handler::{
-    handle_existing_session_selection, handle_group_session_selection, handle_print_layout_schema,
-    handle_print_schema, handle_workspace_selection,
+    handle_existing_session_selection, handle_group_session_selection, handle_make_default_config,
+    handle_print_layout_schema, handle_print_schema, handle_workspace_selection,
 };
 use anyhow::Result;
 
@@ -50,13 +50,20 @@ pub struct Arguments {
     /// Print the configuration file schema.
     ///
     /// This can be used with tools (e.g. language servers) to provide autocompletion and validation when editing your configuration.
-    pub schema: bool,
+    pub print_schema: bool,
 
     #[clap(long)]
     /// Print the local layout configuration file schema.
     ///
     /// This can be used with tools (e.g. language servers) to provide autocompletion and validation when editing your configuration.
-    pub layout_schema: bool,
+    pub print_layout_schema: bool,
+
+    #[clap(long)]
+    /// Make default configuration file.
+    ///
+    /// By default will attempt to write a default configuration file and configuration schema in `$XDG_CONFIG_HOME/twm/`
+    /// Using `-p/--path` with this flag will attempt to write the files to the folder specified.
+    pub make_default_config: bool,
 }
 
 /// Parses the command line arguments and runs the program. Called from `main.rs`.
@@ -64,9 +71,15 @@ pub fn parse() -> Result<()> {
     let args = Arguments::parse();
 
     match args {
-        Arguments { schema: true, .. } => handle_print_schema(),
         Arguments {
-            layout_schema: true,
+            make_default_config: true,
+            ..
+        } => handle_make_default_config(&args),
+        Arguments {
+            print_schema: true, ..
+        } => handle_print_schema(),
+        Arguments {
+            print_layout_schema: true,
             ..
         } => handle_print_layout_schema(),
         Arguments { existing: true, .. } => handle_existing_session_selection(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::handler::{
-    handle_existing_session_selection, handle_group_session_selection, handle_workspace_selection,
+    handle_existing_session_selection, handle_group_session_selection, handle_print_layout_schema,
+    handle_print_schema, handle_workspace_selection,
 };
 use anyhow::Result;
 
@@ -44,6 +45,18 @@ pub struct Arguments {
     #[clap(short, long)]
     /// Don't attach to the workspace session after opening it.
     pub dont_attach: bool,
+
+    #[clap(long)]
+    /// Print the configuration file schema.
+    ///
+    /// This can be used with tools (e.g. language servers) to provide autocompletion and validation when editing your configuration.
+    pub schema: bool,
+
+    #[clap(long)]
+    /// Print the local layout configuration file schema.
+    ///
+    /// This can be used with tools (e.g. language servers) to provide autocompletion and validation when editing your configuration.
+    pub layout_schema: bool,
 }
 
 /// Parses the command line arguments and runs the program. Called from `main.rs`.
@@ -51,6 +64,11 @@ pub fn parse() -> Result<()> {
     let args = Arguments::parse();
 
     match args {
+        Arguments { schema: true, .. } => handle_print_schema(),
+        Arguments {
+            layout_schema: true,
+            ..
+        } => handle_print_layout_schema(),
         Arguments { existing: true, .. } => handle_existing_session_selection(),
         Arguments { group: true, .. } => handle_group_session_selection(&args),
         _ => handle_workspace_selection(&args),

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,9 +87,8 @@ pub struct RawTwmGlobal {
 }
 
 impl RawTwmGlobal {
-    pub fn print_schema() -> Result<()> {
-        println!("{}", serde_json::to_string_pretty(&schema_for!(Self))?);
-        Ok(())
+    pub fn schema() -> Result<String> {
+        Ok(serde_json::to_string_pretty(&schema_for!(Self))?)
     }
 }
 
@@ -109,9 +108,8 @@ pub struct TwmLayout {
 }
 
 impl TwmLayout {
-    pub fn print_schema() -> Result<()> {
-        println!("{}", serde_json::to_string_pretty(&schema_for!(Self))?);
-        Ok(())
+    pub fn schema() -> Result<String> {
+        Ok(serde_json::to_string_pretty(&schema_for!(Self))?)
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::{
     cli::Arguments,
-    config::TwmGlobal,
+    config::{RawTwmGlobal, TwmGlobal, TwmLayout},
     matches::find_workspaces_in_dir,
     tmux::{
         attach_to_tmux_session, get_tmux_sessions, open_workspace, open_workspace_in_group,
@@ -14,6 +14,14 @@ use crate::{
 };
 
 use crate::ui::picker::{Picker, PickerSelection};
+
+pub fn handle_print_schema() -> Result<()> {
+    RawTwmGlobal::print_schema()
+}
+
+pub fn handle_print_layout_schema() -> Result<()> {
+    TwmLayout::print_schema()
+}
 
 pub fn handle_existing_session_selection() -> Result<()> {
     let existing_sessions = get_tmux_sessions()?;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -70,9 +70,11 @@ search_paths:
 exclude_path_components:
   - .git
   - .direnv
+  - .cargo
   - node_modules
   - venv
   - target
+  - __pycache__
 
 max_search_depth: 5
 session_name_path_components: 2

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,6 +1,7 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use clap::crate_name;
 
 use crate::{
     cli::Arguments,
@@ -16,11 +17,83 @@ use crate::{
 use crate::ui::picker::{Picker, PickerSelection};
 
 pub fn handle_print_schema() -> Result<()> {
-    RawTwmGlobal::print_schema()
+    println!("{}", RawTwmGlobal::schema()?);
+    Ok(())
 }
 
 pub fn handle_print_layout_schema() -> Result<()> {
-    TwmLayout::print_schema()
+    println!("{}", TwmLayout::schema()?);
+    Ok(())
+}
+
+pub fn handle_make_default_config(args: &Arguments) -> Result<()> {
+    let config_filename = format!("{}.yaml", crate_name!());
+    let schema_filename = format!("{}.schema.json", crate_name!());
+    let (config_path, schema_path) = if args.path.is_some() {
+        let mut path = PathBuf::from(args.path.as_ref().expect("Path was just checked?"));
+        if path.is_file() {
+            path.pop();
+        }
+        (path.join(&config_filename), path.join(&schema_filename))
+    } else {
+        let base_dirs = xdg::BaseDirectories::with_prefix(crate_name!())?;
+        (
+            base_dirs.get_config_file(&config_filename),
+            base_dirs.get_config_file(&schema_filename),
+        )
+    };
+
+    if config_path.exists() || schema_path.exists() {
+        anyhow::bail!(format!(
+            "Configuration files already exist. Please move or rename any existing files:
+- {}
+- {}
+before running this command again.",
+            config_path.display(),
+            schema_path.display()
+        ));
+    }
+
+    // make sure parent directories exist
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // write the schema to the schema path
+    std::fs::write(schema_path, RawTwmGlobal::schema()?)?;
+    std::fs::write(
+        config_path,
+        format!(
+            r#"# yaml-language-server: $schema=./{}
+search_paths:
+  - "~"
+
+exclude_path_components:
+  - .git
+  - .direnv
+  - node_modules
+  - venv
+  - target
+
+max_search_depth: 5
+session_name_path_components: 2
+
+workspace_definitions:
+  - name: default
+    has_any_file:
+      - .git
+      - .twm.yaml
+    default_layout: default
+
+layouts:
+  - name: default
+    commands:
+      - echo "twm session created in $TWM_ROOT"
+
+"#,
+            schema_filename
+        ),
+    )?;
+    Ok(())
 }
 
 pub fn handle_existing_session_selection() -> Result<()> {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,6 +1,7 @@
+use schemars::JsonSchema;
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, JsonSchema)]
 pub struct LayoutDefinition {
     pub name: String,
     pub inherits: Option<Vec<String>>,

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,5 +1,5 @@
 use crate::cli::Arguments;
-use crate::config::{TwmGlobal, TwmLocal};
+use crate::config::{TwmGlobal, TwmLayout};
 use crate::layout::{get_commands_from_layout, get_commands_from_layout_name, get_layout_names};
 use crate::ui::picker::{Picker, PickerSelection};
 use anyhow::{bail, Context, Result};
@@ -185,7 +185,7 @@ fn get_workspace_commands<'a>(
     twm_config: &'a TwmGlobal,
     cli_layout: Option<&'a str>,
 
-    local_config: Option<&'a TwmLocal>,
+    local_config: Option<&'a TwmLayout>,
 ) -> Result<Option<Vec<&'a str>>> {
     // if user wants to choose a layout do this first
     if let Some(cli_layout) = cli_layout {
@@ -223,8 +223,8 @@ fn get_workspace_commands<'a>(
     }
 }
 
-fn find_config_file(workspace_path: &Path) -> Result<Option<TwmLocal>> {
-    let local_config = TwmLocal::load(workspace_path)?;
+fn find_config_file(workspace_path: &Path) -> Result<Option<TwmLayout>> {
+    let local_config = TwmLayout::load(workspace_path)?;
     if let Some(local_config) = local_config {
         return Ok(Some(local_config));
     }


### PR DESCRIPTION
### Printing Configuration Schemas

- Adds a flag `--print-schema` which prints the configuration schema understood by your version of `twm` to the terminal
- Adds a flag `--print-layout-schema` which prints the layout-configuration schema understood by your version of `twm` to the terminal

### Default configuration

**Does not change the behavior of `twm` when no user-configuration exists**
- Adds a flag `--make-default-config` which creates two files, `twm.yaml` and `twm.schema.json`. By default these files will try to be created in `$XDG_CONFIG_HOME/twm`, but you can pass `-p/--path <PATH>` (e.g. `twm --make-default-config -p .`) to write the files to any directory

### Config path override

- Allows user to override the location of the configuration file via the environment variable `TWM_CONFIG_FILE`. If unset, falls back to XDG dirs same as before