### PR TITLE
Fix double-keystroke bug in layout selection

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,7 @@
-pub mod event;
-pub mod picker;
-pub mod tui;
+mod event;
+mod picker;
+mod tui;
+
+pub use event::EventHandler;
+pub use picker::{Picker, PickerSelection};
+pub use tui::Tui;

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use crossterm::event::{KeyEvent, KeyModifiers};
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use crossterm::event::KeyCode;
 use nucleo::{
@@ -10,7 +9,6 @@ use nucleo::{
     Injector, Nucleo,
 };
 use ratatui::{
-    backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
     style::{Color, Style, Stylize},
     text::{Line, Span},
@@ -18,10 +16,10 @@ use ratatui::{
         block::Position, Block, HighlightSpacing, List, ListDirection, ListItem, ListState,
         Paragraph,
     },
-    Frame, Terminal,
+    Frame,
 };
 
-use super::event::{Event, EventHandler};
+use super::event::Event;
 use super::tui::Tui;
 
 pub enum PickerSelection {
@@ -61,13 +59,7 @@ impl Picker {
         }
     }
 
-    pub fn get_selection(&mut self) -> Result<PickerSelection> {
-        let backend = CrosstermBackend::new(std::io::stderr());
-        let terminal = Terminal::new(backend)?;
-        let events = EventHandler::new(Duration::from_millis(15));
-        let mut tui = Tui::new(terminal, events);
-        tui.enter()?;
-
+    pub fn get_selection(&mut self, tui: &mut Tui) -> Result<PickerSelection> {
         let mut selection = PickerSelection::None;
         while !self.should_exit {
             tui.draw(self)?;
@@ -76,8 +68,6 @@ impl Picker {
                 Event::Key(key_event) => self.update(key_event),
             };
         }
-
-        tui.exit()?;
         Ok(selection)
     }
 

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -5,10 +5,13 @@ use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+use std::time::Duration;
 
 use crate::ui::picker::Picker;
 
-use super::event::EventHandler;
+use super::EventHandler;
 pub type CrosstermTerminal = ratatui::Terminal<ratatui::backend::CrosstermBackend<std::io::Stderr>>;
 
 pub struct Tui {
@@ -17,6 +20,15 @@ pub struct Tui {
 }
 
 impl Tui {
+    pub fn start() -> Result<Self> {
+        let backend = CrosstermBackend::new(std::io::stderr());
+        let terminal = Terminal::new(backend)?;
+        let events = EventHandler::new(Duration::from_millis(15));
+        let mut tui = Self::new(terminal, events);
+        tui.enter()?;
+        Ok(tui)
+    }
+
     pub fn new(terminal: CrosstermTerminal, events: EventHandler) -> Self {
         Self { terminal, events }
     }


### PR DESCRIPTION
Currently there is a bug when selecting a layout where you need to press keys 2-3 times for them to register. I have no idea why, but this fixes it.

Something about starting a Tui instance to select the workspace, closing it, and then starting another one to select the layout doesn't work.

This change starts a Tui instance as needed earlier in the program and passes it around until we're done using it.