### PR TITLE
feat: add configurable sorting and favorites list

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -11,6 +11,9 @@ Your config file should be located at $XDG_CONFIG_HOME/twm/twm.yaml (default: ~/
 - `exclude_path_components`: a list of strings representing folders that will not be searched when searching for workspaces
 - `max_search_depth`: integer, how many directories deep to search your `search_paths` for workspaces
 - `session_name_path_components`: integer, how many directories deep to use by default when generating the name of your tmux session. e.g. if your workspace is `/home/vinny/dev/rust/twm` and `session_name_path_components` is 2, the tmux session will be named `rust/twm`. In the case of name conflicts (e.g. I also have a workspace in `/home/vinny/cache/rust/twm`), the new session would be called `cache/rust/twm`.
+- `session_sort_order`: string, how to sort existing tmux sessions when using `-e/--existing`. Possible values: `asc` (alphabetical A-Z), `desc` (alphabetical Z-A), `last_activity` (most recently used first, default).
+- `workspace_sort_order`: string, how to sort workspaces in the picker when no filter is active. Possible values: `asc` (alphabetical A-Z, default), `desc` (alphabetical Z-A). Note: `last_activity` is not supported for workspaces.
+- `favorites`: a list of workspace paths that can be quickly accessed with `-f/--favorites`. Shell expansion is supported (e.g., `~` will expand to your home directory). Invalid paths will show warnings but won't prevent the picker from opening.
 - `workspace_definitions`: optional, a list of workspace definitions. if no workspaces are defined, git repositories and directories with a `.twm.yaml` config are considered a workspace by default. other than `name` and `default_layout`, the other properties all configure workspace match conditions. any number of conditions can be used in combination with each other, e.g. `has_all_files: [ ".git", "requirements.txt" ]` and `missing_all_files: [ "pyproject.toml", "Pipfile", "poetry.lock"]` can be used together. each workspace definition has the following properties:
   - `name`: string, the name describing the workspace type. must be unique.
   - `has_any_file`: optional list of strings, tells twm to only consider a directory to be a workspace of this type if at least one filename in this list is present
@@ -46,6 +49,14 @@ session_name_path_components: 3    # how many parts of the workspace path to use
                                    # this value will be incremented until a unique session name is found
 
 follow_links: false                # whether to follow symlinks when searching for worksapces (default: true)
+
+session_sort_order: last_activity  # how to sort existing sessions: asc, desc, last_activity (default: last_activity)
+workspace_sort_order: asc          # how to sort workspaces in the picker: asc, desc (default: asc)
+
+favorites:                         # list of favorite workspaces accessible via `twm -f`
+  - ~/Projects/my-main-project
+  - ~/Work/important-repo
+  - ~/dotfiles
 
 workspace_definitions:             # our list of workspaces, each with different properties
     - name: python                 # they all have to be named

--- a/justfile
+++ b/justfile
@@ -1,0 +1,58 @@
+# Default recipe - shows available commands
+default:
+    @just --list
+
+# Format code with cargo fmt
+fmt:
+    cargo fmt
+
+# Check formatting without changes
+fmt-check:
+    cargo fmt -- --check
+
+# Run clippy lints
+lint:
+    cargo clippy -- -D clippy::all
+
+# Run all tests
+test:
+    cargo test
+
+# Check if code compiles (faster than build)
+check:
+    cargo check
+
+# Build in debug mode
+build:
+    cargo build
+
+# Build in release mode
+build-release:
+    cargo build --release
+
+# Install in user mode
+install:
+    cargo install --path .
+
+# Run all CI checks (format, lint, test)
+ci: fmt-check lint test
+
+# Clean build artifacts
+clean:
+    cargo clean
+
+# Generate and print config schema
+schema:
+    cargo run -- --print-config-schema
+
+# Generate and print layout config schema
+layout-schema:
+    cargo run -- --print-layout-config-schema
+
+# Watch for changes and run tests
+watch-test:
+    cargo watch -x test
+
+# Watch for changes and check compilation
+watch-check:
+    cargo watch -x check

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
 use crate::{
     handler::{
-        handle_existing_session_selection, handle_group_session_selection,
-        handle_make_default_config, handle_make_default_layout_config,
-        handle_print_bash_completions, handle_print_config_schema, handle_print_fish_completions,
+        handle_existing_session_selection, handle_favorites_selection,
+        handle_group_session_selection, handle_make_default_config,
+        handle_make_default_layout_config, handle_print_bash_completions,
+        handle_print_config_schema, handle_print_fish_completions,
         handle_print_layout_config_schema, handle_print_man, handle_print_zsh_completions,
         handle_workspace_selection,
     },
@@ -23,6 +24,12 @@ pub struct Arguments {
     ///
     /// This shouldn't be used with other options.
     pub existing: bool,
+
+    #[clap(short, long)]
+    /// Prompt user to select a workspace from the configured favorites list.
+    ///
+    /// Favorites are defined in your configuration file under the `favorites` key.
+    pub favorites: bool,
 
     #[clap(short, long)]
     /// Prompt user to start a new session in the same group as an existing session.
@@ -156,6 +163,8 @@ pub fn parse() -> Result<()> {
             let mut tui = Tui::start()?;
             let res = if args.existing {
                 handle_existing_session_selection(&args, &mut tui)
+            } else if args.favorites {
+                handle_favorites_selection(&args, &mut tui)
             } else if args.group {
                 handle_group_session_selection(&args, &mut tui)
             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,12 +4,26 @@ use crate::workspace::{
     NullCondition, WorkspaceConditionEnum, WorkspaceDefinition,
 };
 use anyhow::{Context, Result};
-use schemars::{JsonSchema, schema_for};
+use schemars::schema_for;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+
+/// Sort order for sessions and workspaces.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SortOrder {
+    /// Sort alphabetically ascending (A-Z)
+    #[default]
+    Asc,
+    /// Sort alphabetically descending (Z-A)
+    Desc,
+    /// Sort by last activity (most recent first) - only applicable for sessions
+    LastActivity,
+}
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -161,6 +175,18 @@ fn default_follow_links() -> bool {
     true
 }
 
+fn default_session_sort_order() -> SortOrder {
+    SortOrder::LastActivity
+}
+
+fn default_workspace_sort_order() -> SortOrder {
+    SortOrder::Asc
+}
+
+fn default_favorites() -> Vec<String> {
+    vec![]
+}
+
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RawTwmGlobal {
@@ -218,6 +244,28 @@ pub struct RawTwmGlobal {
     /// If unset, defaults to true.
     #[serde(default = "default_follow_links")]
     follow_links: bool,
+
+    /// Sort order for existing tmux sessions when using `-e/--existing`.
+    /// If unset, defaults to `last_activity` (most recently used first).
+    ///
+    /// Possible values: `asc`, `desc`, `last_activity`
+    #[serde(default = "default_session_sort_order")]
+    session_sort_order: SortOrder,
+
+    /// Sort order for workspaces in the picker.
+    /// If unset, defaults to `asc` (alphabetically ascending).
+    ///
+    /// Possible values: `asc`, `desc`
+    /// Note: `last_activity` is not supported for workspaces.
+    #[serde(default = "default_workspace_sort_order")]
+    workspace_sort_order: SortOrder,
+
+    /// List of favorite workspace paths that can be quickly accessed with `-f/--favorites`.
+    /// Shell expansion is supported (e.g., `~` will expand to your home directory).
+    ///
+    /// If unset, defaults to an empty list.
+    #[serde(default = "default_favorites")]
+    favorites: Vec<String>,
 }
 
 impl Default for RawTwmGlobal {
@@ -242,6 +290,9 @@ pub struct TwmGlobal {
     pub layouts: Vec<LayoutDefinition>,
     pub max_search_depth: usize,
     pub follow_links: bool,
+    pub session_sort_order: SortOrder,
+    pub workspace_sort_order: SortOrder,
+    pub favorites: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Clone, JsonSchema)]
@@ -275,6 +326,13 @@ impl From<RawTwmGlobal> for TwmGlobal {
             .map(WorkspaceDefinition::from)
             .collect();
 
+        // Also expand favorites paths
+        let favorites: Vec<String> = raw_config
+            .favorites
+            .iter()
+            .map(|path| shellexpand::tilde(path).to_string())
+            .collect();
+
         Self {
             search_paths,
             exclude_path_components,
@@ -283,6 +341,9 @@ impl From<RawTwmGlobal> for TwmGlobal {
             max_search_depth: raw_config.max_search_depth,
             session_name_path_components: raw_config.session_name_path_components,
             follow_links: raw_config.follow_links,
+            session_sort_order: raw_config.session_sort_order,
+            workspace_sort_order: raw_config.workspace_sort_order,
+            favorites,
         }
     }
 }
@@ -357,9 +418,9 @@ impl FromStr for TwmLayout {
         let settings = config::Config::builder()
             .add_source(config::File::from_str(config, config::FileFormat::Yaml))
             .build()
-            .with_context(
-                || "Failed to build configuration. You should never see this. I think.",
-            )?;
+            .with_context(|| {
+                "Failed to build configuration. You should never see this. I think."
+            })?;
 
         let local_config = settings
             .try_deserialize()

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use clap::{CommandFactory, crate_name};
-use clap_complete::{Shell, generate};
+use clap::{crate_name, CommandFactory};
+use clap_complete::{generate, Shell};
 
 use crate::{
     cli::Arguments,
@@ -13,7 +13,7 @@ use crate::{
         session_name_for_path_recursive,
     },
     ui::Tui,
-    workspace::get_workspace_type_for_path,
+    workspace::{get_workspace_type_for_path, path_meets_workspace_conditions},
 };
 
 use crate::ui::{Picker, PickerSelection};
@@ -63,8 +63,8 @@ pub const DEFAULT_LAYOUT_CONFIG_TEMPLATE: &str = r#"layout:
 pub fn handle_make_default_layout_config(args: &Arguments) -> Result<()> {
     let config_filename = format!(".{}.yaml", crate_name!());
 
-    let config_path = if args.path.is_some() {
-        let mut path = PathBuf::from(args.path.as_ref().expect("Just checked?"));
+    let config_path = if let Some(p) = &args.path {
+        let mut path = PathBuf::from(p);
         if path.is_file() {
             path.pop();
         }
@@ -92,8 +92,8 @@ pub fn handle_make_default_layout_config(args: &Arguments) -> Result<()> {
 pub fn handle_make_default_config(args: &Arguments) -> Result<()> {
     let config_filename = format!("{}.yaml", crate_name!());
     let schema_filename = format!("{}.schema.json", crate_name!());
-    let (config_path, schema_path) = if args.path.is_some() {
-        let mut path = PathBuf::from(args.path.as_ref().expect("Path was just checked?"));
+    let (config_path, schema_path) = if let Some(p) = &args.path {
+        let mut path = PathBuf::from(p);
         if path.is_file() {
             path.pop();
         }
@@ -138,7 +138,8 @@ before running this command again.",
 }
 
 pub fn handle_existing_session_selection(args: &Arguments, tui: &mut Tui) -> Result<()> {
-    let existing_sessions = get_tmux_sessions()?;
+    let config = TwmGlobal::load()?;
+    let existing_sessions = get_tmux_sessions(config.session_sort_order)?;
     tui.enter()?;
     let session_name = match Picker::new(
         &existing_sessions,
@@ -159,10 +160,11 @@ pub fn handle_existing_session_selection(args: &Arguments, tui: &mut Tui) -> Res
 }
 
 pub fn handle_group_session_selection(args: &Arguments, tui: &mut Tui) -> Result<()> {
+    let config = TwmGlobal::load()?;
     let group_session_name = if let Some(name) = &args.group_with {
         name.clone()
     } else {
-        let existing_sessions = get_tmux_sessions()?;
+        let existing_sessions = get_tmux_sessions(config.session_sort_order)?;
         tui.enter()?;
         let name = match Picker::new(
             &existing_sessions,
@@ -190,7 +192,8 @@ pub fn handle_workspace_selection(args: &Arguments, tui: &mut Tui) -> Result<()>
             None => anyhow::bail!("Path is not valid UTF-8"),
         }
     } else {
-        let mut picker = Picker::new(&[], "Select a workspace: ".into());
+        let mut picker = Picker::new(&[], "Select a workspace: ".into())
+            .with_sort_order(config.workspace_sort_order);
         let injector = picker.injector.clone();
         let config = config.clone();
         std::thread::spawn(move || {
@@ -217,6 +220,91 @@ pub fn handle_workspace_selection(args: &Arguments, tui: &mut Tui) -> Result<()>
     }
 
     // if we couldn't find a correct session to group with, open the workspace normally
+
+    let workspace_type =
+        get_workspace_type_for_path(Path::new(&workspace_path), &config.workspace_definitions);
+    open_workspace(&workspace_path, workspace_type, &config, args, tui)?;
+
+    Ok(())
+}
+
+pub fn handle_favorites_selection(args: &Arguments, tui: &mut Tui) -> Result<()> {
+    let config = TwmGlobal::load()?;
+
+    if config.favorites.is_empty() {
+        anyhow::bail!(
+            "No favorites configured. Add favorite paths to your config file under the 'favorites' key."
+        );
+    }
+
+    // Validate favorites and collect valid ones with warnings for invalid paths
+    let mut valid_favorites: Vec<String> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    for favorite in &config.favorites {
+        let path = Path::new(favorite);
+
+        if !path.exists() {
+            warnings.push(format!("Favorite path does not exist: {}", favorite));
+            continue;
+        }
+
+        if !path.is_dir() {
+            warnings.push(format!("Favorite path is not a directory: {}", favorite));
+            continue;
+        }
+
+        // Check if it's a valid workspace according to the configuration
+        if !path_meets_workspace_conditions(path, &config.workspace_definitions[0].conditions) {
+            // Still add it, but warn - the user might want to open non-workspace dirs as favorites
+            // We'll use the first workspace definition for validation
+            let is_any_workspace = config
+                .workspace_definitions
+                .iter()
+                .any(|def| path_meets_workspace_conditions(path, &def.conditions));
+
+            if !is_any_workspace {
+                warnings.push(format!(
+                    "Favorite path is not a recognized workspace (no matching workspace definition): {}",
+                    favorite
+                ));
+            }
+        }
+
+        // Canonicalize the path
+        match std::fs::canonicalize(path) {
+            Ok(canonical) => {
+                if let Some(p) = canonical.to_str() {
+                    valid_favorites.push(p.to_owned());
+                }
+            }
+            Err(_) => {
+                warnings.push(format!("Failed to resolve path: {}", favorite));
+            }
+        }
+    }
+
+    // Print warnings to stderr
+    for warning in &warnings {
+        eprintln!("Warning: {}", warning);
+    }
+
+    if valid_favorites.is_empty() {
+        anyhow::bail!(
+            "No valid favorite paths found. Check your configuration and the warnings above."
+        );
+    }
+
+    tui.enter()?;
+    let workspace_path = match Picker::new(&valid_favorites, "Select a favorite workspace: ".into())
+        .with_sort_order(config.workspace_sort_order)
+        .get_selection(tui)?
+    {
+        PickerSelection::None => anyhow::bail!("No workspace selected"),
+        PickerSelection::Selection(s) => s,
+        PickerSelection::ModifiedSelection(s) => s,
+    };
+    tui.exit()?;
 
     let workspace_type =
         get_workspace_type_for_path(Path::new(&workspace_path), &config.workspace_definitions);

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -2,11 +2,11 @@ use crate::config::TwmGlobal;
 use crate::workspace::path_meets_workspace_conditions;
 
 use jwalk::{
-    WalkDir,
     rayon::{
         current_num_threads,
         iter::{ParallelBridge, ParallelIterator},
     },
+    WalkDir,
 };
 use nucleo::Injector;
 

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,9 +1,9 @@
 use crate::cli::Arguments;
-use crate::config::{TwmGlobal, TwmLayout};
+use crate::config::{SortOrder, TwmGlobal, TwmLayout};
 use crate::layout::{get_commands_from_layout, get_commands_from_layout_name, get_layout_names};
 use crate::ui::Tui;
 use crate::ui::{Picker, PickerSelection};
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::{Command, Output};
@@ -54,11 +54,53 @@ fn run_tmux_command(args: &[&str]) -> Result<Output> {
     Ok(output)
 }
 
-pub fn get_tmux_sessions() -> Result<Vec<String>> {
-    let output = run_tmux_command(&["list-sessions", "-F", "#{session_name}"])?;
+/// Session info with name and last activity timestamp
+struct SessionInfo {
+    name: String,
+    last_activity: u64,
+}
+
+pub fn get_tmux_sessions(sort_order: SortOrder) -> Result<Vec<String>> {
+    // Get session name and last_attached timestamp (unix timestamp)
+    let output = run_tmux_command(&[
+        "list-sessions",
+        "-F",
+        "#{session_name}\t#{session_last_attached}",
+    ])?;
     let out_str = String::from_utf8_lossy(&output.stdout);
-    let sessions: Vec<String> = out_str.lines().map(|s| s.to_string()).collect();
-    Ok(sessions)
+
+    let mut sessions: Vec<SessionInfo> = out_str
+        .lines()
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() >= 2 {
+                Some(SessionInfo {
+                    name: parts[0].to_string(),
+                    last_activity: parts[1].parse().unwrap_or(0),
+                })
+            } else if !line.is_empty() {
+                // Fallback if no timestamp available
+                Some(SessionInfo {
+                    name: line.to_string(),
+                    last_activity: 0,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Sort based on the configured order
+    match sort_order {
+        SortOrder::Asc => sessions.sort_by(|a, b| a.name.cmp(&b.name)),
+        SortOrder::Desc => sessions.sort_by(|a, b| b.name.cmp(&a.name)),
+        SortOrder::LastActivity => {
+            // Most recently used first (descending by timestamp)
+            sessions.sort_by(|a, b| b.last_activity.cmp(&a.last_activity))
+        }
+    }
+
+    Ok(sessions.into_iter().map(|s| s.name).collect())
 }
 
 fn create_tmux_session(name: &SessionName, workspace_type: Option<&str>, path: &str) -> Result<()> {

--- a/src/ui/picker.rs
+++ b/src/ui/picker.rs
@@ -3,20 +3,21 @@ use crossterm::event::{KeyEvent, KeyModifiers};
 
 use std::sync::Arc;
 
+use crate::config::SortOrder;
 use crossterm::event::KeyCode;
 use nucleo::{
-    Injector, Nucleo,
     pattern::{CaseMatching, Normalization},
+    Injector, Nucleo,
 };
 use ratatui::{
-    Frame,
     layout::{Constraint, Direction, Layout},
     style::{Color, Style, Stylize},
     text::{Line, Span},
     widgets::{
-        Block, HighlightSpacing, List, ListDirection, ListItem, ListState, Paragraph,
-        block::Position,
+        block::Position, Block, HighlightSpacing, List, ListDirection, ListItem, ListState,
+        Paragraph,
     },
+    Frame,
 };
 
 use super::event::Event;
@@ -36,6 +37,9 @@ pub struct Picker {
     pub injector: Injector<String>,
     prompt: String,
     should_exit: bool,
+    sort_order: Option<SortOrder>,
+    /// Cached sorted items for correct selection when custom sorting is applied
+    cached_items: Vec<String>,
 }
 
 impl Picker {
@@ -56,7 +60,16 @@ impl Picker {
             cursor_pos: 0,
             prompt,
             should_exit: false,
+            sort_order: None,
+            cached_items: Vec::new(),
         }
+    }
+
+    /// Set the sort order for displaying items when no filter is active.
+    /// When a filter is active, Nucleo's fuzzy matching score takes precedence.
+    pub fn with_sort_order(mut self, sort_order: SortOrder) -> Self {
+        self.sort_order = Some(sort_order);
+        self
     }
 
     pub fn get_selection(&mut self, tui: &mut Tui) -> Result<PickerSelection> {
@@ -116,9 +129,35 @@ impl Picker {
     pub fn render(&mut self, frame: &mut Frame) {
         self.matcher.tick(10);
         let snapshot = self.matcher.snapshot();
-        let matches = snapshot
-            .matched_items(..snapshot.matched_item_count())
-            .map(|item| ListItem::new(item.data.as_str()));
+
+        // Collect items - apply custom sorting only when filter is empty
+        self.cached_items = if self.filter.is_empty() && self.sort_order.is_some() {
+            let mut collected: Vec<String> = snapshot
+                .matched_items(..snapshot.matched_item_count())
+                .map(|item| item.data.clone())
+                .collect();
+
+            match self.sort_order {
+                Some(SortOrder::Asc) => collected.sort(),
+                Some(SortOrder::Desc) => collected.sort_by(|a, b| b.cmp(a)),
+                Some(SortOrder::LastActivity) => {
+                    // LastActivity doesn't make sense for workspaces, treat as Asc
+                    collected.sort();
+                }
+                None => {}
+            }
+            collected
+        } else {
+            snapshot
+                .matched_items(..snapshot.matched_item_count())
+                .map(|item| item.data.clone())
+                .collect()
+        };
+
+        let matches = self
+            .cached_items
+            .iter()
+            .map(|item| ListItem::new(item.as_str()));
 
         if let Some(selected) = self.selection.selected() {
             if snapshot.matched_item_count() == 0 {
@@ -147,10 +186,13 @@ impl Picker {
                 ),
             );
 
-        let layout = Layout::new(Direction::Vertical, [
-            Constraint::Length(frame.area().height - 1),
-            Constraint::Length(1),
-        ])
+        let layout = Layout::new(
+            Direction::Vertical,
+            [
+                Constraint::Length(frame.area().height - 1),
+                Constraint::Length(1),
+            ],
+        )
         .split(frame.area());
 
         frame.render_stateful_widget(table, layout[0], &mut self.selection);
@@ -168,11 +210,8 @@ impl Picker {
 
     fn get_selected_text(&self) -> Option<String> {
         if let Some(index) = self.selection.selected() {
-            return self
-                .matcher
-                .snapshot()
-                .get_matched_item(index as u32)
-                .map(|item| item.data.to_owned());
+            // Use cached_items which respects our custom sorting
+            return self.cached_items.get(index).cloned();
         }
 
         None

--- a/src/ui/tui.rs
+++ b/src/ui/tui.rs
@@ -5,8 +5,8 @@ use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
     terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
 use std::time::Duration;
 
 use crate::ui::picker::Picker;


### PR DESCRIPTION
## ⚠️ Disclaimer

This PR was developed with AI assistance (Claude). I don't have prior experience with Rust, so **please review this PR thoroughly** before merging. I've done my best to follow the project's conventions and philosophy, but there may be edge cases or idiomatic Rust patterns I've missed.

---

## Summary

This PR adds two new features to twm:

### 1. Configurable Sort Order

New configuration options to control how sessions and workspaces are sorted in the picker:

- `session_sort_order`: Sort existing tmux sessions (`asc`, `desc`, `last_activity`)
  - Default: `last_activity` (most recently used first)
- `workspace_sort_order`: Sort workspaces in the picker (`asc`, `desc`)
  - Default: `asc` (alphabetical)

The workspace sorting only applies when no filter is active—once the user starts typing, Nucleo's fuzzy matching score takes precedence for optimal search results.

### 2. Favorites List

A new `favorites` configuration option for quick access to frequently used workspaces:
